### PR TITLE
Migrate goreleaser config to version 2 (fixes the v0.3.0 release failure)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,44 +1,46 @@
 # Visit https://goreleaser.com for documentation on how to customize this
-# behavior.
+# behavior. Migrated to the version-2 config format required by GoReleaser
+# v2+ (which the release workflow installs as `latest`).
+version: 2
+
 before:
   hooks:
-    # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - formats: [zip]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--pinentry-mode"
@@ -51,9 +53,9 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.3.0 (unreleased)
+## v0.3.0 (2026-07-06)
 
 Complete rework: fakecloud is now a Terraform learning playground built
 around one primitive — a tic-tac-toe board.


### PR DESCRIPTION
## Why

The v0.3.0 release run [failed in 23 seconds](https://github.com/pokgak/terraform-provider-fakecloud/actions/runs/28807642804): the release workflow installs goreleaser `latest`, which since v2 refuses pre-v2 config files —

```
only version: 2 configuration files are supported, yours is version: 0
```

The existing `.goreleaser.yml` predates goreleaser v2 (it last shipped v0.2.7 under goreleaser v1).

## What

- Migrate the config to the version-2 format: `version: 2` header, `archives.format` → `formats`, `changelog.skip` → `disable`. Build targets, signing, checksum, and registry-manifest handling are unchanged.
- Stamp the v0.3.0 CHANGELOG entry with today's date (couldn't ride the release tag).

## Verification

- `goreleaser check` passes with v2.17.0 — the exact version the failed action resolved.
- A full local `goreleaser release --snapshot` succeeded: all six platform zips (linux/darwin/windows × amd64/arm64) plus SHA256SUMS produced.

## After merging — re-cutting v0.3.0

The tag must move to include this fix (the workflow builds the tagged commit). Nothing was published for the old tag, so moving it is safe:

```sh
git push origin :refs/tags/v0.3.0   # delete the failed tag
git fetch origin
git tag -f v0.3.0 origin/main
git push origin v0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153uCqiJXK5Mng2uPVDqSPj

---
_Generated by [Claude Code](https://claude.ai/code/session_0153uCqiJXK5Mng2uPVDqSPj)_