### PR TITLE
Bump workflow action pins off deprecated Node 20; migrate golangci config to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           args: release --clean
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,10 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
+          - '1.5.*'
+          - '1.9.*'
+          - '1.12.*'
+          - '1.15.*'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,23 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
 
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -65,12 +65,12 @@ jobs:
           - '1.3.*'
           - '1.4.*'
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,32 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
+version: "2"
+
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - godot
-    - gofmt
-    - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
-    - staticcheck
-    - tenv
+    - staticcheck # includes the former gosimple
     - unconvert
     - unparam
     - unused
-    - vet
+    - usetesting # replaces the removed tenv
+
+# gofmt is a formatter in golangci-lint v2, not a linter.
+# (exportloopref was dropped: obsolete since Go 1.22's loop variable change.)
+formatters:
+  enable:
+    - gofmt

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -82,14 +82,14 @@ func (c *Client) do(method, path string, body, out any) error {
 	if err != nil {
 		return fmt.Errorf("cannot reach fakecloud at %s: %w (is the server running?)", c.endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		var apiErr struct {
 			Error string `json:"error"`
 		}
-		json.NewDecoder(resp.Body).Decode(&apiErr)
-		if apiErr.Error == "" {
+		// A non-JSON error body just falls through to the HTTP status text.
+		if decodeErr := json.NewDecoder(resp.Body).Decode(&apiErr); decodeErr != nil || apiErr.Error == "" {
 			apiErr.Error = resp.Status
 		}
 		return &APIError{StatusCode: resp.StatusCode, Message: apiErr.Error}

--- a/internal/provider/board_data_source.go
+++ b/internal/provider/board_data_source.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -67,7 +68,15 @@ func (d *boardDataSource) Configure(_ context.Context, req datasource.ConfigureR
 	if req.ProviderData == nil {
 		return
 	}
-	d.client = req.ProviderData.(*client.Client)
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected provider data",
+			fmt.Sprintf("expected *client.Client, got %T — this is a bug in the provider", req.ProviderData),
+		)
+		return
+	}
+	d.client = c
 }
 
 func (d *boardDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/provider/board_resource.go
+++ b/internal/provider/board_resource.go
@@ -104,7 +104,15 @@ func (r *boardResource) Configure(_ context.Context, req resource.ConfigureReque
 	if req.ProviderData == nil {
 		return
 	}
-	r.client = req.ProviderData.(*client.Client)
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected provider data",
+			fmt.Sprintf("expected *client.Client, got %T — this is a bug in the provider", req.ProviderData),
+		)
+		return
+	}
+	r.client = c
 }
 
 func boardToModel(ctx context.Context, board client.Board) (boardModel, error) {

--- a/internal/provider/move_resource.go
+++ b/internal/provider/move_resource.go
@@ -91,7 +91,15 @@ func (r *moveResource) Configure(_ context.Context, req resource.ConfigureReques
 	if req.ProviderData == nil {
 		return
 	}
-	r.client = req.ProviderData.(*client.Client)
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected provider data",
+			fmt.Sprintf("expected *client.Client, got %T — this is a bug in the provider", req.ProviderData),
+		)
+		return
+	}
+	r.client = c
 }
 
 func (r *moveResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -154,7 +162,7 @@ func (r *moveResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 // ImportState lets you adopt a mark made outside Terraform (e.g. by clicking
-// a cell on the dashboard): terraform import fakecloud_tictactoe_move.NAME ID
+// a cell on the dashboard): terraform import fakecloud_tictactoe_move.NAME ID.
 func (r *moveResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id, err := strconv.ParseInt(req.ID, 10, 64)
 	if err != nil {

--- a/internal/provider/nameplate_resource.go
+++ b/internal/provider/nameplate_resource.go
@@ -74,7 +74,15 @@ func (r *nameplateResource) Configure(_ context.Context, req resource.ConfigureR
 	if req.ProviderData == nil {
 		return
 	}
-	r.client = req.ProviderData.(*client.Client)
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected provider data",
+			fmt.Sprintf("expected *client.Client, got %T — this is a bug in the provider", req.ProviderData),
+		)
+		return
+	}
+	r.client = c
 }
 
 func (r *nameplateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {


### PR DESCRIPTION
Fixes #30 (the actionable part — the two cache warnings in that issue were a transient GitHub-side outage, nothing to fix).

## Action pins

All pins bumped to the latest stable release of each action, keeping the pin-by-SHA style (SHAs resolved from the peeled tag commits):

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4.0.0 | v7.0.0 |
| `actions/setup-go` | v4.1.0 | v6.5.0 |
| `crazy-max/ghaction-import-gpg` | v6.0.0 | v7.0.0 |
| `goreleaser/goreleaser-action` | v5.0.0 | v7.2.3 |
| `hashicorp/setup-terraform` | v2.0.3 | v4.0.1 |
| `golangci/golangci-lint-action` | v3.7.0 | v9.3.0 |

## golangci migration (the non-mechanical part)

`golangci-lint-action` v9 runs golangci-lint **v2**, which rejects the old config outright. `.golangci.yml` is migrated to the version-2 format:

- `gofmt` moved to the new `formatters` section
- `gosimple` folded into `staticcheck` (upstream merge)
- `tenv` → `usetesting` (upstream replacement)
- `exportloopref` dropped (obsolete since Go 1.22's loop-variable semantics)
- `vet` → `govet`, `disable-all` → `default: none`, `max-per-linter` → `max-issues-per-linter`

Running golangci-lint v2 also surfaced **7 real findings** in the code that would have failed the first CI run, fixed here rather than suppressed:

- 4× `forcetypeassert`: the `req.ProviderData.(*client.Client)` assertions in the four `Configure` methods are now checked, with a diagnostic on mismatch
- 2× `errcheck`: the API client's ignored `resp.Body.Close()` and error-body `Decode` returns are now handled (a non-JSON error body falls through to the HTTP status text)
- 1× `godot` comment fix

## Also

Refreshed the acceptance-test matrix from Terraform `1.0.*`–`1.4.*` to `1.5.*` / `1.9.*` / `1.12.*` / `1.15.*` (verified against releases.hashicorp.com). Note the acceptance job remains a no-op until the provider grows `*_test.go` files — left as the remaining unchecked item in #30.

## Verification

- Locally with golangci-lint v2.12.2 (what `version: latest` resolves to): `config verify` passes, `run ./...` reports **0 issues**; `go build` / `go vet` clean.
- The Tests workflow runs on this PR with the new pins — that's the live check for the pin SHAs themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153uCqiJXK5Mng2uPVDqSPj

---
_Generated by [Claude Code](https://claude.ai/code/session_0153uCqiJXK5Mng2uPVDqSPj)_